### PR TITLE
Fix handling of data stream behavior on initial subscribe

### DIFF
--- a/app/src/main/java/com/cronus/zdone/api/TasksRepositoryImpl.kt
+++ b/app/src/main/java/com/cronus/zdone/api/TasksRepositoryImpl.kt
@@ -18,11 +18,12 @@ class TasksRepositoryImpl @Inject constructor(
 
     private val CACHE_REFRESH_TIME = 2 * 60 * 1_000_000_000L // 2 mins in nanoseconds
 
-    var cachedData: Tasks? = null
-    var requestId: String? = null
-    var lastRequestTime: Long = 0
-    var observers = Collections.synchronizedSet(HashSet<ObservableEmitter<Tasks>>())
-    var dataStream = observe(Observable.create<Tasks> { observer ->
+    private var cachedData: Tasks? = null
+    private var requestId: String? = null
+    private var lastRequestTime: Long = 0
+    var observers: MutableSet<ObservableEmitter<Tasks>> =
+        Collections.synchronizedSet(HashSet<ObservableEmitter<Tasks>>())
+    private val dataStream = observe(Observable.create<Tasks> { observer ->
         observers.add(observer)
         observer.setCancellable { observers.remove(observer) }
 

--- a/app/src/main/java/com/cronus/zdone/api/TasksRepositoryImpl.kt
+++ b/app/src/main/java/com/cronus/zdone/api/TasksRepositoryImpl.kt
@@ -26,12 +26,12 @@ class TasksRepositoryImpl @Inject constructor(
         observers.add(observer)
         observer.setCancellable { observers.remove(observer) }
 
-        cachedData?.let {
-            val timeElapsed = System.nanoTime() - lastRequestTime
-            if (timeElapsed < CACHE_REFRESH_TIME) {
-                observer.onNext(it)
-            }
-        } ?: refreshTaskData()
+        val timeElapsed = System.nanoTime() - lastRequestTime
+        if (timeElapsed < CACHE_REFRESH_TIME) {
+            cachedData?.let { observer.onNext(it) }
+        } else {
+            refreshTaskData()
+        }
     })
 
     override fun refreshTaskData() {


### PR DESCRIPTION
With previous system, if you had a cached value that was stale, you wouldn't actually request new data when subscribed.

This new logic guarantees that either the cached data is sent back or new data is fetched on initial subscribe