### PR TITLE
Add ability to stop current work session from inside settings screen

### DIFF
--- a/app/src/main/java/com/cronus/zdone/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/cronus/zdone/settings/SettingsScreen.kt
@@ -11,6 +11,7 @@ import com.cronus.zdone.dagger.ScreenInjector
 import com.cronus.zdone.home.NoFilterTaskShowingStrategy
 import com.cronus.zdone.home.TaskShowerStrategyProvider
 import com.cronus.zdone.home.TimeOfDayTaskShowingStrategy
+import com.cronus.zdone.timer.TaskExecutionManager
 import com.dropbox.android.external.store4.StoreResponse
 import com.wealthfront.magellan.NavigationType
 import com.wealthfront.magellan.rx2.RxScreen
@@ -24,6 +25,7 @@ class SettingsScreen @Inject constructor(
     val apiTokenManager: ApiTokenManager,
     val workTimeManager: WorkTimeManager,
     val tasksRepository: TasksRepository,
+    val taskExecutionManager: TaskExecutionManager,
     val sharedPreferences: SharedPreferences,
     val taskShowerStrategyProvider: TaskShowerStrategyProvider
 ) : RxScreen<SettingsView>() {
@@ -105,5 +107,9 @@ class SettingsScreen @Inject constructor(
             .putBoolean("section_tasks_mode_key", enabled)
             .apply()
         taskShowerStrategyProvider.setStrategy(if (enabled) TimeOfDayTaskShowingStrategy() else NoFilterTaskShowingStrategy())
+    }
+
+    fun stopCurrentWorkSession() {
+        taskExecutionManager.cancelTasks()
     }
 }

--- a/app/src/main/java/com/cronus/zdone/settings/SettingsView.kt
+++ b/app/src/main/java/com/cronus/zdone/settings/SettingsView.kt
@@ -40,6 +40,9 @@ class SettingsView(context: Context) : BaseScreenView<SettingsScreen>(context) {
         sectionTasksByTimeOfDaySwitch.setOnCheckedChangeListener { _, isChecked ->
             screen.setSectionTasksByTimeOfDayEnabled(isChecked)
         }
+        stopCurrentTasksButton.setOnClickListener {
+            screen.stopCurrentWorkSession()
+        }
         logoutButton.setOnClickListener {
             screen.logout()
         }

--- a/app/src/main/res/layout/settings.xml
+++ b/app/src/main/res/layout/settings.xml
@@ -90,6 +90,13 @@
         android:paddingTop="@dimen/normalPadding">
 
         <Button
+            android:id="@+id/stopCurrentTasksButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/normalPadding"
+            android:text="@string/settings_stop_working" />
+
+        <Button
             android:id="@+id/logoutButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,6 +36,7 @@
   <string name="settings_log_out">Log Out</string>
   <string name="upcoming_tasks_empty_title">Select some tasks or roll with the standard set</string>
   <string name="upcoming_tasks">Upcoming Tasks</string>
+  <string name="settings_stop_working">Stop working</string>
 
   <string-array name="time_granularity_options">
     <item>Weekly</item>


### PR DESCRIPTION
It's annoying to not be able to stop a work session if you make a mistake. Previously, you'd have to resort to desperate measures like killing the app. Now, it's still kind of annoying but less so. You just go to the settings screen and click "stop work session" and the tasks will be cancelled (the notification will eventually clear, it's taking a long time on my OP device for some unknown reason)